### PR TITLE
Define 0^0 to be 1 for FieldElements

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,4 @@
 [alias]
 tr = "test --release"
+bt = "build --tests"
 bs = "build --tests --features strict"

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -139,8 +139,7 @@ mod tests {
                 eval_poly(
                     FieldElement::root(U256::from(4u64))
                         .unwrap()
-                        .pow(U256::from(i))
-                        .unwrap(),
+                        .pow(U256::from(i)),
                     &coefficients,
                 )
             })
@@ -163,12 +162,7 @@ mod tests {
         ];
         let eighth_root_of_unity = FieldElement::root(U256::from(8u64)).unwrap();
         let polynomial_values: Vec<FieldElement> = (0..8u64)
-            .map(|i| {
-                eval_poly(
-                    eighth_root_of_unity.pow(U256::from(i)).unwrap(),
-                    &coefficients,
-                )
-            })
+            .map(|i| eval_poly(eighth_root_of_unity.pow(U256::from(i)), &coefficients))
             .collect();
 
         assert_eq!(fft(FieldElement::ONE, &coefficients), polynomial_values);
@@ -211,11 +205,11 @@ mod tests {
 
         let mut res = fft(root.clone(), &vector);
 
-        assert_eq!(root.pow(U256::from(8u64)).unwrap(), FieldElement::ONE);
+        assert_eq!(root.pow(U256::from(8u64)), FieldElement::ONE);
         for (i, x) in fft(root.clone(), &vector).into_iter().enumerate() {
             assert_eq!(
                 x,
-                eval_poly(root.clone().pow(U256::from(i as u64)).unwrap(), &vector)
+                eval_poly(root.clone().pow(U256::from(i as u64)), &vector)
             );
         }
 

--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -43,17 +43,17 @@ pub fn eval_whole_loop(
     let trace_len = eval_domain_size / beta;
 
     let omega = FieldElement::root(U256::from(trace_len * beta)).unwrap();
-    let g = omega.pow(U256::from(beta)).unwrap();
+    let g = omega.pow(U256::from(beta));
     let gen = FieldElement::GENERATOR;
 
     let mut CC = Vec::with_capacity(eval_domain_size_usize);
-    let g_trace = g.pow(U256::from(trace_len - 1)).unwrap();
-    let g_claim = g.pow(U256::from(claim_index)).unwrap();
+    let g_trace = g.pow(U256::from(trace_len - 1));
+    let g_claim = g.pow(U256::from(claim_index));
     let x = gen.clone();
-    let x_trace = (&x).pow(U256::from(trace_len)).unwrap();
-    let x_1023 = (&x).pow(U256::from(trace_len - 1)).unwrap();
-    let omega_trace = (&omega).pow(U256::from(trace_len)).unwrap();
-    let omega_1023 = (&omega).pow(U256::from(trace_len - 1)).unwrap();
+    let x_trace = (&x).pow(U256::from(trace_len));
+    let x_1023 = (&x).pow(U256::from(trace_len - 1));
+    let omega_trace = (&omega).pow(U256::from(trace_len));
+    let omega_1023 = (&omega).pow(U256::from(trace_len - 1));
 
     let x_omega_cycle = geometric_series(&x, &omega, eval_domain_size_usize);
     let x_trace_cycle = geometric_series(&x_trace, &omega_trace, eval_domain_size_usize);
@@ -136,20 +136,19 @@ pub fn eval_c_direct(
     let eval_P0 = |x: FieldElement| -> FieldElement { eval_poly(x, polynomials[0]) };
     let eval_P1 = |x: FieldElement| -> FieldElement { eval_poly(x, polynomials[1]) };
     let eval_C0 = |x: FieldElement| -> FieldElement {
-        ((eval_P0(&x * &g) - eval_P1(x.clone()))
-            * (&x - &g.pow(U256::from(trace_len - 1)).unwrap()))
-            / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+        ((eval_P0(&x * &g) - eval_P1(x.clone())) * (&x - &g.pow(U256::from(trace_len - 1))))
+            / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
     };
     let eval_C1 = |x: FieldElement| -> FieldElement {
         ((eval_P1(&x * &g) - eval_P0(x.clone()) - eval_P1(x.clone()))
-            * (&x - (&g.pow(U256::from(trace_len - 1)).unwrap())))
-            / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+            * (&x - (&g.pow(U256::from(trace_len - 1)))))
+            / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
     };
     let eval_C2 = |x: FieldElement| -> FieldElement {
         ((eval_P0(x.clone()) - FieldElement::ONE) * FieldElement::ONE) / (&x - FieldElement::ONE)
     };
     let eval_C3 = |x: FieldElement| -> FieldElement {
-        (eval_P0(x.clone()) - claim) / (&x - &g.pow(U256::from(claim_index)).unwrap())
+        (eval_P0(x.clone()) - claim) / (&x - &g.pow(U256::from(claim_index)))
     };
 
     let deg_adj = |degree_bound: u64,
@@ -166,25 +165,21 @@ pub fn eval_c_direct(
         r += &constraint_coefficients[0] * &eval_C0(x.clone());
         r += &constraint_coefficients[1]
             * &eval_C0(x.clone())
-            * (&x)
-                .pow(U256::from(deg_adj(
-                    composition_degree_bound,
-                    trace_len - 1,
-                    1,
-                    trace_len,
-                )))
-                .unwrap();
+            * (&x).pow(U256::from(deg_adj(
+                composition_degree_bound,
+                trace_len - 1,
+                1,
+                trace_len,
+            )));
         r += &constraint_coefficients[2] * &eval_C1(x.clone());
         r += &constraint_coefficients[3]
             * &eval_C1(x.clone())
-            * (&x)
-                .pow(U256::from(deg_adj(
-                    composition_degree_bound,
-                    trace_len - 1,
-                    1,
-                    trace_len,
-                )))
-                .unwrap();
+            * (&x).pow(U256::from(deg_adj(
+                composition_degree_bound,
+                trace_len - 1,
+                1,
+                trace_len,
+            )));
         r += &constraint_coefficients[4] * &eval_C2(x.clone());
         r += &constraint_coefficients[5]
             * &eval_C2(x.clone())
@@ -193,8 +188,7 @@ pub fn eval_c_direct(
                 trace_len - 1,
                 0,
                 1,
-            )))
-            .unwrap();
+            )));
         r += &constraint_coefficients[6] * (eval_C3.clone())(x.clone());
         r += &constraint_coefficients[7]
             * &eval_C3(x.clone())
@@ -203,8 +197,7 @@ pub fn eval_c_direct(
                 trace_len - 1,
                 0,
                 1,
-            )))
-            .unwrap();
+            )));
         r
     };
     eval_C(x.clone())
@@ -232,10 +225,10 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
     let mut eval_offset_x = Vec::with_capacity((eval_domain_size) as usize);
 
     for i in 0..trace_len {
-        trace_x.push(g.pow(U256::from(i)).unwrap());
+        trace_x.push(g.pow(U256::from(i)));
     }
     for i in 0..(eval_domain_size) {
-        let hold = omega.pow(U256::from(i)).unwrap();
+        let hold = omega.pow(U256::from(i));
         eval_x.push(hold.clone());
         eval_offset_x.push(hold * &gen);
     }
@@ -262,7 +255,7 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
         let mut vals = fft_cofactor(
             g.clone(),
             &(TP0.as_slice()),
-            &gen * (&omega.pow(U256::from(j)).unwrap()),
+            &gen * (&omega.pow(U256::from(j))),
         );
         for i in 0..trace_len {
             LDE0[((i * beta + j) % (eval_domain_size)) as usize] = vals[i as usize].clone();
@@ -271,7 +264,7 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
         vals = fft_cofactor(
             g.clone(),
             &(TP1.as_slice()),
-            &gen * (&omega.pow(U256::from(j)).unwrap()),
+            &gen * (&omega.pow(U256::from(j))),
         );
         for i in 0..trace_len {
             LDE1[((i * beta + j) % (eval_domain_size)) as usize] = vals[i as usize].clone();
@@ -312,20 +305,19 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
     let eval_P0 = |x: FieldElement| -> FieldElement { eval_poly(x, &TP0) };
     let eval_P1 = |x: FieldElement| -> FieldElement { eval_poly(x, &TP1) };
     let eval_C0 = |x: FieldElement| -> FieldElement {
-        ((eval_P0(&x * &g) - eval_P1(x.clone()))
-            * (&x - &g.pow(U256::from(trace_len - 1)).unwrap()))
-            / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+        ((eval_P0(&x * &g) - eval_P1(x.clone())) * (&x - &g.pow(U256::from(trace_len - 1))))
+            / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
     };
     let eval_C1 = |x: FieldElement| -> FieldElement {
         ((eval_P1(&x * &g) - eval_P0(x.clone()) - eval_P1(x.clone()))
-            * (&x - &g.pow(U256::from(trace_len - 1)).unwrap()))
-            / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+            * (&x - &g.pow(U256::from(trace_len - 1))))
+            / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
     };
     let eval_C2 = |x: FieldElement| -> FieldElement {
         ((eval_P0(x.clone()) - FieldElement::ONE) * FieldElement::ONE) / (&x - FieldElement::ONE)
     };
     let eval_C3 = |x: FieldElement| -> FieldElement {
-        (eval_P0(x.clone()) - claim_fib.clone()) / (&x - &g.pow(U256::from(claim_index)).unwrap())
+        (eval_P0(x.clone()) - claim_fib.clone()) / (&x - &g.pow(U256::from(claim_index)))
     };
 
     let deg_adj = |degree_bound: u64,
@@ -342,25 +334,21 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
         r += &constraint_coefficients[0] * &eval_C0(x.clone());
         r += &constraint_coefficients[1]
             * &eval_C0(x.clone())
-            * (&x)
-                .pow(U256::from(deg_adj(
-                    composition_degree_bound,
-                    trace_len - 1,
-                    1,
-                    trace_len,
-                )))
-                .unwrap();
+            * (&x).pow(U256::from(deg_adj(
+                composition_degree_bound,
+                trace_len - 1,
+                1,
+                trace_len,
+            )));
         r += &constraint_coefficients[2] * &eval_C1(x.clone());
         r += &constraint_coefficients[3]
             * &eval_C1(x.clone())
-            * (&x)
-                .pow(U256::from(deg_adj(
-                    composition_degree_bound,
-                    trace_len - 1,
-                    1,
-                    trace_len,
-                )))
-                .unwrap();
+            * (&x).pow(U256::from(deg_adj(
+                composition_degree_bound,
+                trace_len - 1,
+                1,
+                trace_len,
+            )));
         r += &constraint_coefficients[4] * &eval_C2(x.clone());
         r += &constraint_coefficients[5]
             * &eval_C2(x.clone())
@@ -369,8 +357,7 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
                 trace_len - 1,
                 0,
                 1,
-            )))
-            .unwrap();
+            )));
         r += &constraint_coefficients[6] * &eval_C3(x.clone());
         r += &constraint_coefficients[7]
             * &eval_C3(x.clone())
@@ -379,19 +366,18 @@ pub fn fib_proof(witness: FieldElement) -> Channel {
                 trace_len - 1,
                 0,
                 1,
-            )))
-            .unwrap();
+            )));
         r
     };
 
     let mut CC = vec![FieldElement::ZERO; eval_domain_size_usize];
-    let g_trace = g.pow(U256::from(trace_len - 1)).unwrap();
-    let g_claim = g.pow(U256::from(claim_index)).unwrap();
+    let g_trace = g.pow(U256::from(trace_len - 1));
+    let g_claim = g.pow(U256::from(claim_index));
     let x = gen.clone();
-    let mut x_trace = (&x).pow(U256::from(trace_len)).unwrap();
-    let mut x_1023 = (&x).pow(U256::from(1023_u64)).unwrap();
-    let omega_trace = (&omega).pow(U256::from(trace_len)).unwrap();
-    let omega_1023 = (&omega).pow(U256::from(1023_u64)).unwrap();
+    let mut x_trace = (&x).pow(U256::from(trace_len));
+    let mut x_1023 = (&x).pow(U256::from(1023_u64));
+    let omega_trace = (&omega).pow(U256::from(trace_len));
+    let omega_1023 = (&omega).pow(U256::from(1023_u64));
 
     let mut x = gen.clone();
     let mut x_omega_cycle = Vec::with_capacity(eval_domain_size_usize);
@@ -696,11 +682,8 @@ mod tests {
         let eval_domain_size = trace_len * beta;
         let eval_domain_size_usize = eval_domain_size as usize;
 
-        assert_eq!(
-            omega.pow(U256::from(eval_domain_size)).unwrap(),
-            FieldElement::ONE
-        );
-        assert_eq!(g.pow(U256::from(trace_len)).unwrap(), FieldElement::ONE);
+        assert_eq!(omega.pow(U256::from(eval_domain_size)), FieldElement::ONE);
+        assert_eq!(g.pow(U256::from(trace_len)), FieldElement::ONE);
 
         let gen = FieldElement::from(U256::from(3_u64));
         let mut trace_x = Vec::with_capacity(trace_len as usize);
@@ -708,10 +691,10 @@ mod tests {
         let mut eval_offset_x = Vec::with_capacity((eval_domain_size) as usize);
 
         for i in 0..trace_len {
-            trace_x.push(g.pow(U256::from(i)).unwrap());
+            trace_x.push(g.pow(U256::from(i)));
         }
         for i in 0..(eval_domain_size) {
-            let hold = omega.pow(U256::from(i)).unwrap();
+            let hold = omega.pow(U256::from(i));
             eval_x.push(hold.clone());
             eval_offset_x.push(hold * &gen);
         }
@@ -757,7 +740,7 @@ mod tests {
             let mut vals = fft_cofactor(
                 g.clone(),
                 &(TP0.as_slice()),
-                &gen * (&omega.pow(U256::from(j)).unwrap()),
+                &gen * (&omega.pow(U256::from(j))),
             );
             for i in 0..trace_len {
                 LDE0[((i * beta + j) % (eval_domain_size)) as usize] = vals[i as usize].clone();
@@ -766,7 +749,7 @@ mod tests {
             vals = fft_cofactor(
                 g.clone(),
                 &(TP1.as_slice()),
-                &gen * (&omega.pow(U256::from(j)).unwrap()),
+                &gen * (&omega.pow(U256::from(j))),
             );
             for i in 0..trace_len {
                 LDE1[((i * beta + j) % (eval_domain_size)) as usize] = vals[i as usize].clone();
@@ -835,22 +818,20 @@ mod tests {
         let eval_P0 = |x: FieldElement| -> FieldElement { eval_poly(x, &TP0) };
         let eval_P1 = |x: FieldElement| -> FieldElement { eval_poly(x, &TP1) };
         let eval_C0 = |x: FieldElement| -> FieldElement {
-            ((eval_P0(&x * &g) - eval_P1(x.clone()))
-                * (&x - &g.pow(U256::from(trace_len - 1)).unwrap()))
-                / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+            ((eval_P0(&x * &g) - eval_P1(x.clone())) * (&x - &g.pow(U256::from(trace_len - 1))))
+                / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
         };
         let eval_C1 = |x: FieldElement| -> FieldElement {
             ((eval_P1(&x * &g) - eval_P0(x.clone()) - eval_P1(x.clone()))
-                * (&x - &g.pow(U256::from(trace_len - 1)).unwrap()))
-                / (&x.pow(U256::from(trace_len)).unwrap() - FieldElement::ONE)
+                * (&x - &g.pow(U256::from(trace_len - 1))))
+                / (&x.pow(U256::from(trace_len)) - FieldElement::ONE)
         };
         let eval_C2 = |x: FieldElement| -> FieldElement {
             ((eval_P0(x.clone()) - FieldElement::ONE) * FieldElement::ONE)
                 / (&x - FieldElement::ONE)
         };
         let eval_C3 = |x: FieldElement| -> FieldElement {
-            (eval_P0(x.clone()) - claim_fib.clone())
-                / (&x - &g.pow(U256::from(claim_index)).unwrap())
+            (eval_P0(x.clone()) - claim_fib.clone()) / (&x - &g.pow(U256::from(claim_index)))
         };
 
         let deg_adj = |degree_bound: u64,
@@ -867,25 +848,21 @@ mod tests {
             r += &constraint_coefficients[0] * &eval_C0(x.clone());
             r += &constraint_coefficients[1]
                 * &eval_C0(x.clone())
-                * (&x)
-                    .pow(U256::from(deg_adj(
-                        composition_degree_bound,
-                        trace_len - 1,
-                        1,
-                        trace_len,
-                    )))
-                    .unwrap();
+                * (&x).pow(U256::from(deg_adj(
+                    composition_degree_bound,
+                    trace_len - 1,
+                    1,
+                    trace_len,
+                )));
             r += &constraint_coefficients[2] * &eval_C1(x.clone());
             r += &constraint_coefficients[3]
                 * &eval_C1(x.clone())
-                * (&x)
-                    .pow(U256::from(deg_adj(
-                        composition_degree_bound,
-                        trace_len - 1,
-                        1,
-                        trace_len,
-                    )))
-                    .unwrap();
+                * (&x).pow(U256::from(deg_adj(
+                    composition_degree_bound,
+                    trace_len - 1,
+                    1,
+                    trace_len,
+                )));
             r += &constraint_coefficients[4] * &eval_C2(x.clone());
             r += &constraint_coefficients[5]
                 * &eval_C2(x.clone())
@@ -894,8 +871,7 @@ mod tests {
                     trace_len - 1,
                     0,
                     1,
-                )))
-                .unwrap();
+                )));
             r += &constraint_coefficients[6] * &eval_C3(x.clone());
             r += &constraint_coefficients[7]
                 * &eval_C3(x.clone())
@@ -904,8 +880,7 @@ mod tests {
                     trace_len - 1,
                     0,
                     1,
-                )))
-                .unwrap();
+                )));
             return r;
         };
         let z = FieldElement::from(u256h!(
@@ -917,13 +892,13 @@ mod tests {
         );
 
         let mut CC = vec![FieldElement::ZERO; eval_domain_size_usize];
-        let g_trace = g.pow(U256::from(trace_len - 1)).unwrap();
-        let g_claim = g.pow(U256::from(claim_index)).unwrap();
+        let g_trace = g.pow(U256::from(trace_len - 1));
+        let g_claim = g.pow(U256::from(claim_index));
         let x = gen.clone();
-        let mut x_trace = (&x).pow(U256::from(trace_len)).unwrap();
-        let mut x_1023 = (&x).pow(U256::from(1023_u64)).unwrap();
-        let omega_trace = (&omega).pow(U256::from(trace_len)).unwrap();
-        let omega_1023 = (&omega).pow(U256::from(1023_u64)).unwrap();
+        let mut x_trace = (&x).pow(U256::from(trace_len));
+        let mut x_1023 = (&x).pow(U256::from(1023_u64));
+        let omega_trace = (&omega).pow(U256::from(trace_len));
+        let omega_1023 = (&omega).pow(U256::from(1023_u64));
 
         let mut x = gen.clone();
         let mut x_omega_cycle = Vec::with_capacity(eval_domain_size_usize);
@@ -1141,8 +1116,7 @@ mod tests {
                 FieldElement::from(u256h!(
                     "011d07d97880b4dc0234b46e6d4b9bd4a1f811a9e3bc8e32cc4074a0c13a1d0b"
                 ))
-                .pow(U256::from(42_u64))
-                .unwrap(),
+                .pow(U256::from(42_u64)),
                 &(last_layer_coefficents.as_slice())
             ),
             fri[5][42]

--- a/src/field.rs
+++ b/src/field.rs
@@ -89,22 +89,18 @@ impl FieldElement {
         *self = self.neg()
     }
 
-    pub fn pow(&self, exponent: U256) -> Option<FieldElement> {
+    pub fn pow(&self, exponent: U256) -> FieldElement {
+        let mut result = FieldElement::ONE;
+        let mut square = self.clone();
         let mut remaining_exponent = exponent;
-        if self.is_zero() && remaining_exponent.is_zero() {
-            None
-        } else {
-            let mut result = FieldElement::ONE;
-            let mut square = self.clone();
-            while !remaining_exponent.is_zero() {
-                if remaining_exponent.is_odd() {
-                    result *= &square;
-                }
-                remaining_exponent >>= 1;
-                square = square.square();
+        while !remaining_exponent.is_zero() {
+            if remaining_exponent.is_odd() {
+                result *= &square;
             }
-            Some(result)
+            remaining_exponent >>= 1;
+            square = square.square();
         }
+        result
     }
 
     // OPT: replace this with a constant array of roots of unity.
@@ -116,7 +112,7 @@ impl FieldElement {
         if rem != U256::ZERO {
             return None;
         }
-        FieldElement::GENERATOR.pow(q)
+        Some(FieldElement::GENERATOR.pow(q))
     }
 }
 
@@ -391,39 +387,27 @@ mod tests {
 
     #[quickcheck]
     fn pow_0(a: FieldElement) -> bool {
-        match a.pow(U256::from(0u128)) {
-            None => a.is_zero(),
-            Some(result) => result == FieldElement::ONE,
-        }
+        a.pow(U256::from(0u128)) == FieldElement::ONE
     }
 
     #[quickcheck]
     fn pow_1(a: FieldElement) -> bool {
-        match a.pow(U256::from(1u128)) {
-            None => false,
-            Some(result) => result == a,
-        }
+        a.pow(U256::from(1u128)) == a
     }
 
     #[quickcheck]
     fn pow_2(a: FieldElement) -> bool {
-        match a.pow(U256::from(2u128)) {
-            None => false,
-            Some(result) => result == a.square(),
-        }
+        a.pow(U256::from(2u128)) == a.square()
     }
 
     #[quickcheck]
     fn pow_n(a: FieldElement, n: usize) -> bool {
-        match a.pow(U256::from(n as u128)) {
-            None => a.is_zero() && n == 0,
-            Some(result) => result == repeat_n(a, n).product(),
-        }
+        a.pow(U256::from(n as u128)) == repeat_n(a, n).product()
     }
 
     #[quickcheck]
     fn fermats_little_theorem(a: FieldElement) -> bool {
-        a.pow(MODULUS).unwrap() == a
+        a.pow(MODULUS) == a
     }
 
     #[test]
@@ -454,7 +438,7 @@ mod tests {
         let powers_of_two = (0..193).map(|n| U256::ONE << n);
         for n in powers_of_two {
             let root_of_unity = FieldElement::root(n.clone()).unwrap();
-            assert_eq!(root_of_unity.pow(n).unwrap(), FieldElement::ONE);
+            assert_eq!(root_of_unity.pow(n), FieldElement::ONE);
         }
     }
 }

--- a/src/proofs.rs
+++ b/src/proofs.rs
@@ -81,7 +81,7 @@ pub fn stark_proof(
 ) -> Channel {
     let trace_len = (trace.elements.len() / trace.COLS) as u64;
     let omega = FieldElement::root(U256::from(trace_len * beta)).unwrap();
-    let g = omega.pow(U256::from(beta)).unwrap();
+    let g = omega.pow(U256::from(beta));
     let eval_domain_size = trace_len * beta;
     let gen = FieldElement::GENERATOR;
 
@@ -115,7 +115,7 @@ pub fn stark_proof(
                             fft_cofactor(
                                 g.clone(),
                                 TPn[x].as_slice(),
-                                &gen * (&omega.pow(U256::from(j as u64)).unwrap()),
+                                &gen * (&omega.pow(U256::from(j as u64))),
                             ),
                         )
                     })
@@ -471,7 +471,7 @@ pub fn geometric_series(base: &FieldElement, step: &FieldElement, len: usize) ->
         .par_chunks_mut(step_len)
         .enumerate()
         .for_each(|(i, slice)| {
-            let mut hold = base * step.pow(U256::from((i * step_len) as u64)).unwrap();
+            let mut hold = base * step.pow(U256::from((i * step_len) as u64));
             for element in slice.iter_mut() {
                 *element = hold.clone();
                 hold *= step;

--- a/src/square_root.rs
+++ b/src/square_root.rs
@@ -13,10 +13,7 @@ pub fn square_root(a: &FieldElement) -> Option<FieldElement> {
 
 // Returns the result of (a/p) != -1, where (a/p) is the Legendre symbol.
 fn is_quadratic_residue(a: &FieldElement) -> bool {
-    match a.pow(MODULUS >> 1) {
-        None => panic!(),
-        Some(value) => value != FieldElement::NEGATIVE_ONE,
-    }
+    a.pow(MODULUS >> 1) != FieldElement::NEGATIVE_ONE
 }
 
 // These two constants are chosen so that 1 + SIGNIFICAND << BINARY_EXPONENT == MODULUS.
@@ -41,13 +38,11 @@ fn tonelli_shanks(a: &FieldElement) -> FieldElement {
 
     let mut c: FieldElement = INITIAL_C;
     // OPT: Raising a to a fixed power is a good candidate for an addition chain.
-    let mut root: FieldElement = a.pow((SIGNIFICAND + U256::from(1u128)) >> 1).unwrap();
+    let mut root: FieldElement = a.pow((SIGNIFICAND + U256::from(1u128)) >> 1);
 
     for i in 1..BINARY_EXPONENT {
         // OPT: Precompute the inverse of a.
-        if (root.square() / a)
-            .pow(U256::from(1u128) << (BINARY_EXPONENT - i - 1))
-            .unwrap()
+        if (root.square() / a).pow(U256::from(1u128) << (BINARY_EXPONENT - i - 1))
             == FieldElement::NEGATIVE_ONE
         {
             root *= &c;
@@ -78,7 +73,7 @@ mod tests {
 
     #[test]
     fn initial_c_is_correct() {
-        assert_eq!(INITIAL_C, FieldElement::GENERATOR.pow(SIGNIFICAND).unwrap());
+        assert_eq!(INITIAL_C, FieldElement::GENERATOR.pow(SIGNIFICAND));
     }
 
     #[quickcheck]

--- a/src/u256.rs
+++ b/src/u256.rs
@@ -379,7 +379,7 @@ impl U256 {
                     result *= &square;
                 }
                 remaining_exponent >>= 1;
-                square *= square.clone(); //OPT - eleminate .clone()
+                square *= square.clone(); //OPT - eliminate .clone()
             }
             Some(result)
         }


### PR DESCRIPTION
Removes unwrap calls that were previously necessary and adds a `bt` alias for `build --tests`