### PR TITLE
 Harmonize fib_proof_test and fib_test_1024_python_witness 

### DIFF
--- a/stark/src/fft.rs
+++ b/stark/src/fft.rs
@@ -4,8 +4,7 @@ use u256::U256;
 
 pub fn fft(a: &[FieldElement]) -> Vec<FieldElement> {
     let mut result = a.to_vec();
-    let root =
-        FieldElement::root(result.len()).expect("No root of unity for input length");
+    let root = FieldElement::root(result.len()).expect("No root of unity for input length");
     bit_reversal_fft(result.as_mut_slice(), root);
     bit_reversal_permute(result.as_mut_slice());
     result

--- a/stark/src/proofs.rs
+++ b/stark/src/proofs.rs
@@ -701,7 +701,7 @@ fn decommit_fri_layers_and_trees(
 mod tests {
     use super::*;
     use crate::{fibonacci::*, verifier::*};
-    use macros_decl::{hex, u256h, field_element};
+    use macros_decl::{field_element, hex, u256h};
     use u256::U256;
 
     #[test]


### PR DESCRIPTION
Previously, these two tests, which have the same public and private inputs, resulted in differenct final coin digests because `fib_proof_test` pulled an extra random element. Now they have the same ending proof digest.