### PR TITLE
Update cargo aliases

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
 [alias]
-tr = "test --release"
-bt = "build --tests"
-bs = "build --tests --features strict"
+t = "test --all-features"
+tr = "test --release --all-features"
+bt = "build --all-features --all-targets"


### PR DESCRIPTION
we don't need `cargo bs` anymore since `#![deny(warnings)]` is the standard everywhere now.