### PR TITLE
Assembly optimization of poly_loop_1

### DIFF
--- a/crypto/stark-verifier-ethereum/contracts/default_cs.sol
+++ b/crypto/stark-verifier-ethereum/contracts/default_cs.sol
@@ -247,8 +247,8 @@ abstract contract DefaultConstraintSystem is ConstraintSystem, Trace  {
             inverses := add(inverses, 32)
             inverses := add(inverses, mul(32, inverseOffset))
 
-            let layout_end := add(layout, mul(bound, 32))
-            for {} lt(layout, layout_end) {} {
+            let trace_oods_values_end := add(trace_oods_values, mul(bound, 32))
+            for {} lt(trace_oods_values, trace_oods_values_end) {} {
                 let numerator
                 {
                 // Load directly from the data pointer

--- a/crypto/stark-verifier-ethereum/contracts/default_cs.sol
+++ b/crypto/stark-verifier-ethereum/contracts/default_cs.sol
@@ -233,7 +233,7 @@ abstract contract DefaultConstraintSystem is ConstraintSystem, Trace  {
             }
             // We record total length to use in the loop bound
             let bound := mload(trace_oods_values)
-            // Then because the arrays are structued as [length][data start]
+            // Then because the arrays are structured as [length][data start]
             // we move the pointers forward by one machine word.
             trace_oods_values := add(trace_oods_values, 32)
             // // Trace oods values is a special case, where we always want
@@ -247,10 +247,8 @@ abstract contract DefaultConstraintSystem is ConstraintSystem, Trace  {
             inverses := add(inverses, 32)
             inverses := add(inverses, mul(32, inverseOffset))
 
-            for {let j := 0}
-                lt(j, bound)
-                {j := add(j, 1)}
-            {
+            let layout_end := add(layout, mul(bound, 32))
+            for {} lt(layout, layout_end) {} {
                 let numerator
                 {
                 // Load directly from the data pointer

--- a/crypto/stark-verifier-ethereum/contracts/testing_contracts/recurrence_trace.sol
+++ b/crypto/stark-verifier-ethereum/contracts/testing_contracts/recurrence_trace.sol
@@ -12,9 +12,9 @@ abstract contract RecurrenceTrace is DefaultConstraintSystem(2, 2, 2, 16) {
     function layout_col_major() internal override pure returns (uint256[] memory) {
         uint256[] memory result = new uint256[](8);
         (result[0], result[1]) = (0, 0);
-        (result[2], result[3]) = (0, 1);
-        (result[4], result[5]) = (1, 0);
-        (result[6], result[7]) = (1, 1);
+        (result[2], result[3]) = (0, 32);
+        (result[4], result[5]) = (32, 0);
+        (result[6], result[7]) = (32, 32);
         return result;
     }
 

--- a/crypto/stark/src/solidity_verifier.rs
+++ b/crypto/stark/src/solidity_verifier.rs
@@ -746,13 +746,19 @@ abstract contract {}Trace is DefaultConstraintSystem({}, {}, {}, {}) {{",
             RationalExpression::Trace(i, j) => (i, j),
             _ => panic!("Non trace rational expression in rows"),
         };
+        // This adds code which writes the 32*row and thirty two times
+        // the index of the row to the kth and k+1-th positions.
+        // this will let us lookup the row and index of the row
+        // when we are using assembly
+        // Note the factor of 32 is the because 32 bytes is the word size
+        // of evm memory.
         trace_layout_contract.push_str(&format!(
             "    (result[{}], result[{}]) = ({}, {});",
             k,
             k + 1,
-            i,
+            32*i,
             // TODO - Support negative rows
-            rows.iter()
+            32*rows.iter()
                 .position(|x| x == &(TryInto::<usize>::try_into(*j).unwrap()))
                 .unwrap()
         ));

--- a/crypto/stark/src/solidity_verifier.rs
+++ b/crypto/stark/src/solidity_verifier.rs
@@ -756,9 +756,10 @@ abstract contract {}Trace is DefaultConstraintSystem({}, {}, {}, {}) {{",
             "    (result[{}], result[{}]) = ({}, {});",
             k,
             k + 1,
-            32*i,
+            32 * i,
             // TODO - Support negative rows
-            32*rows.iter()
+            32 * rows
+                .iter()
                 .position(|x| x == &(TryInto::<usize>::try_into(*j).unwrap()))
                 .unwrap()
         ));


### PR DESCRIPTION
Added new assembly refactoring and changes to the autogen to enable it.
Benchmarks of a 64 transactions proof with all modifications:
Before:
Gas used for get_polynomial_points_loop_1 : [1860440]
Total Gas Estimate : [9713190]
After:
Gas used for get_polynomial_points_loop_1 : [662680]
Total Gas Estimate : [8568254]
The saving of this pr in that case are around 1.2 million gas

- [ ] Tag the PR with `wip` while in development.
- [ ] Assign yourself as to the PR
- [ ] Assign relevant labels such as `bug`, `enhancement`.
- [ ] Request reviews if the PR is large, complex or you would like an extra pair of eyes to go over it.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] Add new entries to the `Changelog.md`.
- [ ] Update version numbers as needed.

Semver: https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md

https://semver.org/
