### PR TITLE
Annotate the incompatible forbid lint in algebra

### DIFF
--- a/algebra/u256/src/lib.rs
+++ b/algebra/u256/src/lib.rs
@@ -32,7 +32,7 @@
     trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
-    unsafe_code,
+    // unsafe_code,
     variant_size_differences
 )]
 #![cfg_attr(feature = "std", warn(missing_debug_implementations,))]


### PR DESCRIPTION
- [ ] Tag the PR with `wip` while in development.
- [ ] Assign yourself as to the PR
- [ ] Assign relevant labels such as `bug`, `enhancement`.
- [ ] Request reviews if the PR is large, complex or you would like an extra pair of eyes to go over it.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] Add new entries to the `Changelog.md`.
- [ ] Update version numbers as needed.

Semver: https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md

https://semver.org/

---

```
 𝝺 rustc --version
rustc 1.50.0-nightly (c919f490b 2020-11-17)
 𝝺 cargo build
   Compiling zkp-u256 v0.2.0
error[E0453]: warn(unsafe_code) incompatible with previous forbid in same scope
  --> /Users/mercury/.cargo/registry/src/github.com-1ecc6299db9ec823/zkp-u256-0.2.0/src/lib.rs:35:5
   |
6  | #![forbid(unsafe_code)]
   |           ----------- `forbid` level set here
...
35 |     unsafe_code,
   |     ^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0453`.
error: could not compile `zkp-u256`

To learn more, run the command again with --verbose.
```