### PR TITLE
fix small_fib example for indices of 2^x

### DIFF
--- a/crypto/stark/examples/small_fib.rs
+++ b/crypto/stark/examples/small_fib.rs
@@ -26,7 +26,7 @@ impl Verifiable for Claim {
         seed.extend_from_slice(&self.value.as_montgomery().to_bytes_be());
 
         // Constraint repetitions
-        let trace_length = self.index.next_power_of_two();
+        let trace_length = (self.index + 1).next_power_of_two();
         let trace_generator = FieldElement::root(trace_length).unwrap();
         let g = Constant(trace_generator);
         let on_row = |index| (X - g.pow(index)).inv();
@@ -44,7 +44,7 @@ impl Verifiable for Claim {
 
 impl Provable<&Witness> for Claim {
     fn trace(&self, witness: &Witness) -> TraceTable {
-        let trace_length = self.index.next_power_of_two();
+        let trace_length = (self.index + 1).next_power_of_two();
         let mut trace = TraceTable::new(trace_length, 2);
         trace[(0, 0)] = 1.into();
         trace[(0, 1)] = witness.secret.clone();


### PR DESCRIPTION
This PR fixes small_fib example for indices of format 2^x. 

When testing claims with index: 2^x, x >=1, value 1 passes the proof verification. I think the reason is how the trace is constructed. 

Trace length is defined as power of two:

```rust
let trace_length = self.index.next_power_of_two();
```

But if `self.index` is already power of two, `trace_length == self.index`. It can be a bit misleading that `next` keyword returns [greater or equal power of two](https://doc.rust-lang.org/std/primitive.u32.html#method.next_power_of_two)

Thus if I change it to

```rust
let trace_length = (self.index + 1).next_power_of_two();
```

all indices work fine now.

- [ ] Tag the PR with `wip` while in development.
- [ ] Assign yourself as to the PR
- [ ] Assign relevant labels such as `bug`, `enhancement`.
- [ ] Request reviews if the PR is large, complex or you would like an extra pair of eyes to go over it.
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation as needed.
- [ ] Add new entries to the `Changelog.md`.
- [ ] Update version numbers as needed.


https://semver.org/
